### PR TITLE
Add PHP 8 compatibility

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -477,12 +477,12 @@ class JsonMapper
                 $isNullable = false;
                 $rparams = $rmeth->getParameters();
                 if (count($rparams) > 0) {
-                    $pclass = $rparams[0]->getClass();
+                    $ptype = PHP_MAJOR_VERSION >= 7 ? $rparams[0]->getType() : $rparams[0]->getClass();
                     $isNullable = $rparams[0]->allowsNull();
-                    if ($pclass !== null) {
+                    if ($ptype !== null) {
                         return array(
                             true, $rmeth,
-                            '\\' . $pclass->getName(),
+                            '\\' . $ptype,
                             $isNullable,
                         );
                     }


### PR DESCRIPTION
`ReflectionParameter::getClass` is deprecated in PHP 8, replaced with `ReflectionParameter::getType` for PHP >= 7.
`ReflectionType::getName()` also changed to implicit `ReflectionType::__toString()`, because `ReflectionUnionType` wont support `getName` method (but anyway union types is not supported, will fail later).